### PR TITLE
Guide conversion

### DIFF
--- a/scenarios/dev/guide_conversion.py
+++ b/scenarios/dev/guide_conversion.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import yaml
+import sys
+# from pprint import pprint as print
+
+
+def process_answers(answers, type):
+    result = []
+    for i, a in enumerate(answers):
+        answer = dict()
+        answer["answer_type"] = type
+        answer["value"] = a["Value"]
+        answer["points_possible"] = a["Points"]
+        result.append(answer)
+
+    return result 
+
+
+questions_path = sys.argv[1]
+with open(questions_path, "r") as f:
+    questions = yaml.safe_load(f)
+
+
+question_count = 0
+result = dict()
+while question_count < len(questions):
+    q = dict()
+    q["question_num"] = question_count + 1
+    q["type"] = "question"
+    q["content"] = questions[question_count]["Text"]
+    q["answers"] = process_answers(
+        questions[question_count]["Answers"], questions[question_count]["Type"]
+    )
+    q["points_possible"] = questions[question_count]["Points"]
+
+    q_key = "Question" + str(question_count + 1)
+    result[q_key] = q
+    question_count += 1
+
+yaml_string = yaml.dump(result, stream=None, sort_keys=False)
+print(yaml_string)

--- a/scenarios/prod/elf_infection/guide_content.yml
+++ b/scenarios/prod/elf_infection/guide_content.yml
@@ -1,0 +1,14 @@
+ScenarioTitle: Elf Infection
+
+contentDefinitions:
+  Reading1: &reading1
+    type: reading
+    content: |
+      ### place holder
+
+studentGuide:
+  chapters:
+    - chapter_num: 1
+      title: Elf Infection
+      content_array:
+        - *reading1

--- a/scenarios/prod/metasploitable/guide_content.yml
+++ b/scenarios/prod/metasploitable/guide_content.yml
@@ -1,0 +1,279 @@
+ScenarioTitle: Metasploitable
+
+contentDefinitions:
+  Reading1: &reading1
+    type: reading
+    content: |
+      ## What is Metasploit
+      Metasploit is a framework for automating the process of exploiting vulnerabilities in application software. It has tools to support the cyber kill chain. which consists of the steps: 
+      - reconnaissance, identifying the target and software services running on the target
+      - finding vulnerabilities, this may include CVEs for the specific software versions running on the target and severity of the vulnerabilities
+      - weaponization, identifying exploits that could be used for the vulnerabilities
+      - delivery, in order to get the exploit to the target, it may be necessary to bypass firewalls
+      - exploitation, choosing a payload, producing packets that contain the exploit with payload and delivering them to the target
+      - persistence, creating accounts, backdoors, beacons, etc. 
+
+  Reading2: &reading2
+    type: reading
+    content: |
+      ## Learning Objectives
+      - use the Metasploit shell.
+      - identify targets and services running on open ports
+      - given the service running and the version, find known vulnerabilities and severity.
+      - find exploits provided by the Metasploit framework to use.
+      - use the Metasploit Framework to exploit a vulnerable service.
+
+  Reading3: &reading3
+    type: reading
+    content: |
+      ## Basic Metasploit Commands 
+
+      > Square brackets indicate the command input.
+
+      - `msfconsole`: opens the Metasploit shell, which allows for Metasploit commands to be run.
+
+      - `help`: when used alone, shows the possible options; when used with a command as input, shows information on the specified command.
+
+      - `search [search_term]`: searches the Metasploit vulnerability database and returns the available exploit module names.
+
+      - `use [module_name]`: tells Metasploit which exploit is being used.
+
+      - `back`: tells Metasploit to stop using the current exploit.
+
+      - `options`: shows the options that can be set for the exploit currently in use. (NOTE: some options are required for the exploit to be run.)
+
+      - `set [option] [value]`: sets the given option to the given value for the exploit currently in use.
+
+      - `exploit`: tells Metasploit to try to run the current exploit.
+
+      - `exit`: can be used to exit the Metasploit command line and return to the bash shell (`quit` can be used for the same purpose).
+
+      > Note: options such as RHOSTS which holds information for the target ip address will likely have to be set for each exploit used.
+
+      ### Example use of Metasploit
+
+      The following is an example use of the metasploit framework that has been generalized to show how the given commands can be used.
+
+      <!--![Metasploit Command Line Example](/assets/img/Metasploitable/m-h_example_cmd_line.png)-->
+
+      ```
+      msf5 > search exploit
+
+       Matching Modules
+       ================
+
+          #  Name                                 Disclosure Date  Rank       Check  Description
+          -  -                                 ---------------  ----       -----  -----------
+          0  type/os/directory/exploit_name  xxxx-xx-xx       excellent  Yes    Short description of the exploit
+
+
+       msf5 > use type/os/directory/exploit_name
+       msf5 exploit(os/directory/exploit_name) > options
+
+       Module options (type/os/directory/exploit_name):
+
+          Name    Current Setting  Required  Description
+          -    ---------------  --------  -----------
+          RHOSTS                   yes       The target address range or CIDR identifier
+          RPORT   xxxx             yes       The target port (TCP)
+
+
+       Exploit target:
+
+          Id  Name
+          --  -
+          0   Automatic Target
+
+
+       msf5 exploit(os/directory/exploit_name) > set RHOSTS target
+       RHOSTS => target
+       msf5 exploit(os/directory/exploit_name) > exploit
+       msf5 >
+       msf5 >
+       msf5 exploit(os/directory/exploit_name) > back
+       msf5 >
+      ```
+
+      <!--
+      <pre>
+      msf > use windows/smb/ms08_067_netapi
+      exploit(ms08_067_netapi) > show options
+      exploit(ms08_067_netapi) > set RHOST 10.0.0.1
+      exploit(ms08_067_netapi) > show targets
+      exploit(ms08_067_netapi) > set target 0
+      </pre>
+      -->
+
+  Reading4: &reading4
+    type: reading
+    content: |
+      ## Services
+
+      The following is a list of the types of vulnerable services provided by Metasploitable
+
+      - A compiler
+
+      - An internet relay chat (irc)
+
+      - Two file transfer protocols (ftp)
+
+      - An http service (php_cgi)
+
+      - An sql database
+
+  Reading5: &reading5
+    type: reading
+    content: |
+      ## Information
+
+      Once you have logged into the attacker machine, you should be able to run nmap, which is the standard tool for scanning a target. The use of nmap
+      is covered in the scenarios SSH_inception and Total Recon. In this exercise, the target machine can be accessed using the keyword `target` instead of scanning a network to find the IP Address.
+
+      It is recommended that when you scan the target machine, to scan all ports from 0 to 65535. Once you have identified the open ports you can narrow down the range of ports that you scan for additional information.
+
+      When you scan the target machine you should see 15 open ports.
+
+      The next step is to identify services with known vulnerabilites.
+
+      When looking for exploits to use on a service, we highly recommend that you only try exploits that are ranked `excellent`.
+
+  Reading6: &reading6
+    type: reading
+    content: |
+      ## Example Use of Metasploit
+      #
+
+      Using a basic nmap scan, we can see that an http service is running on port 80. This service will be used as an example of how to use Metasploit. 
+
+      Open the Metasploit shell using `msfconsole`
+
+      Use the Metasploit search command to find a usable http exploit. Notice that if you just search for http (`search http`), you will be given a few over two thousand results. This is a few results too many, so instead we can search for `php_cgi` to find a single usable result. Note that in other cases the number of results will be more managable, so do not worry about trying to search for specific exploits with other services.
+
+      Using `search php_cgi` will give us one result. We can now use the `use` command followed by the exploit name to tell Metasploit that we want to use this exploit.
+
+      Once we are using the exploit we can now make sure that all of the exploits options are properly set. To do so, we will use the `options` command.
+
+      The options command shows us that there are four required options, and that three of them are already set. We can use the `set` command to set the `RHOSTS` option. The `RHOSTS` option specifies the target address. `set RHOSTS target`
+
+      Once all the required options are set, we can use the `exploit` command to run the exploit.
+
+      Some exploits will result in a meterpreter shell, we can get to a normal shell by entering the command `shell`.
+  Reading7: &reading7
+    type: reading
+    content: |
+      ## Exercises
+      #
+      Now that you have had some practice with the http php exploit, use the information given above to find and exploit the five remaining services.
+
+  Question1: &question1
+    question_num: 1
+    type: question
+    content: What is the version of the vulnerable FTP service?
+    answers:
+    - answer_type: String
+      value: 2.3.4
+      points_possible: 5
+    points_possible: 5
+  Question2: &question2
+    question_num: 2
+    type: question
+    content: What is the Metasploit module used to exploit the above service?
+    answers:
+    - answer_type: String
+      value: exploit/unix/ftp/vsftpd_234_backdoor
+      points_possible: 5
+    points_possible: 5
+  Question3: &question3
+    question_num: 3
+    type: question
+    content: What user does the above exploit log you into?
+    answers:
+    - answer_type: String
+      value: root
+      points_possible: 5
+    points_possible: 5
+  Question4: &question4
+    question_num: 4
+    type: question
+    content: What is the exploit you can use on port 80 that gets you a meterpreter
+      shell?
+    answers:
+    - answer_type: String
+      value: exploit/multi/http/php_cgi_arg_injection
+      points_possible: 5
+    points_possible: 5
+  Question5: &question5
+    question_num: 5
+    type: question
+    content: What is the full MySQL version running on the target?
+    answers:
+    - answer_type: String
+      value: 5.0.51a-3ubuntu5
+      points_possible: 5
+    points_possible: 5
+  Question6: &question6
+    question_num: 6
+    type: question
+    content: What is the highest port open on the target host?
+    answers:
+    - answer_type: String
+      value: 6697
+      points_possible: 5
+    points_possible: 5
+  Question7: &question7
+    question_num: 7
+    type: question
+    content: What service is running on the above port?
+    answers:
+    - answer_type: String
+      value: IRC
+      points_possible: 5
+    points_possible: 5
+  Question8: &question8
+    question_num: 8
+    type: question
+    content: What is the admin email of the above service?
+    answers:
+    - answer_type: String
+      value: admin@Metasploitable.LAN
+      points_possible: 5
+    points_possible: 5
+
+studentGuide:
+  chapters:
+    - chapter_num: 1
+      title: What is Metasploitable
+      content_array:
+        - *reading1
+    - chapter_num: 2
+      title: Learning Objectives
+      content_array:
+        - *reading2
+    - chapter_num: 3
+      title: Basic Metasploit Commands
+      content_array:
+        - *reading3
+    - chapter_num: 4
+      title: Services
+      content_array:
+        - *reading4
+    - chapter_num: 5
+      title: Information
+      content_array:
+        - *reading5
+    - chapter_num: 6
+      title: Example Use of Metasploit
+      content_array:
+        - *reading6
+    - chapter_num: 7
+      title: Exercises
+      content_array:
+        - *reading7
+        - *question1
+        - *question2
+        - *question3
+        - *question4
+        - *question5
+        - *question6
+        - *question7
+        - *question8

--- a/scenarios/prod/ransomware/guide_content.yml
+++ b/scenarios/prod/ransomware/guide_content.yml
@@ -1,0 +1,14 @@
+ScenarioTitle: Ransomware
+
+contentDefinitions:
+  Reading1: &reading1
+    type: reading
+    content: |
+      ### place holder
+
+studentGuide:
+  chapters:
+    - chapter_num: 1
+      title: Ransomware
+      content_array:
+        - *reading1

--- a/scenarios/prod/treasure_hunt/guide_content.yml
+++ b/scenarios/prod/treasure_hunt/guide_content.yml
@@ -1,1 +1,357 @@
-PLACEHOLDER FOR TREASURE HUNT GUIDE
+ScenarioTitle: TreasureHunt
+
+contentDefinitions:
+  Reading1: &reading1
+    type: reading
+    content: |
+      ## Description
+
+      Treasure Hunt is an exercise that teaches about permissions and other security loopholes in
+      Linux. In this virtual machine there are 16 imaginary users. Somewhere in his/her home
+      directory, each of these imaginary users has a “secret” file named username-secret.<ext>
+      (where <ext> is a file extension) whose contents are intended to be private (readable only by
+      the user and no one else). However, each of their secret files can actually be read by other
+      users who are both determined and clever. 
+
+      Your goal is to collect the contents of as many of the
+      sixteen secret files as you can.
+
+
+
+      ### Background
+      There are often multiple users on the same system or network. Given this case, how does a
+      system determine who is able to access specific files?
+
+      Linux system of file access permissions are used to control who is able to read, write and execute certain files. This is used both to keep
+      user files private as well as to protect critical system files. In order to obtain many of the secrets
+      in this exercise, you will need to understand the read, write, and execute permissions as well as
+      how permissions are applied to the owner, group owner, and every user. 
+
+      If you are unfamiliar with linux permissions, see the section on Linux File Permissions in the Student Tutorials
+      section below.
+
+      This exercise also utilizes password cracking for a few users. That password cracking method
+      that you will work with utilizes linux password hashes. This exercise is not intended to teach
+      about hashes and password security techniques. If you are unfamiliar with the general idea of
+      them, a quick web search should catch you up with the basics. 
+
+      The files that contain the password hashes are not publicly available on linux systems, but we have made them so for this
+      exercise and will show where to find them. Hopefully, this will give you an idea if the passwords
+      you use are secure or not!
+
+
+      You will also run into the .htaccess file in this exercise. This is a configuration file for Apache
+      Web Server. It is used for many things but here it is only used from user authorization. You
+      should be able to figure it out when you come across it. If not, a simple web search will help you
+      out again.
+
+        
+      ### Learning Objectives
+      Know the difference between read, write, and execute permissions and how this affects
+      directories and files U
+
+      Understand linux groups
+
+      Understand what Set User ID and Set Group ID do
+
+      Know how to find a file’s permissions and interpret this and similar lines ‘-rwsr-xr-x‘
+
+      Be able to create a symbolic link and know what it does
+
+      Recognize what sorts of passwords are easily cracked from known password hashes
+
+      Have a moderate understanding of some basic linux tools and how to use them
+
+      ## Instructions
+      Connect to the scenario via your instructor’s directions, or as displayed on the EDURange page.
+
+      Once logged in, it is your goal to find the secrets of the following 16 fake users:
+
+      * Alice Wan (awan)
+      * Bob Duomo (bduomo)
+      * Cathy Dry (cdry)
+      * Debbie Shi (dshi)
+      * Ellen Quintus (equintus)
+      * Fred Sexon (fsexon)
+      * George Hepta (ghepta)
+      *  Helen Ochoa (hochoa)
+      * Inna Nunez (inunez)
+      * Jack Dekka (jdekka)
+      * Karen Elva (kelva)
+      * Loretta Douzette (Idouzette)
+      * Patricia Kaideka (pkaideka)
+      * Pyotr Theodore Radessime (pradessime)
+      * Quinn Sanera (qsanera)
+      * Tudor Daforth (tdaforth)
+
+
+      ## Important Disclaimer:
+      Accessing some secret files will require that you make changes to certain files/directories in the
+      accounts of the fake users. Once you determine the secret, be sure to undo any changes that
+      you make so that you leave the system exactly in the same state that you found it. 
+
+      Otherwise, you could (1) make it very easy for others to access the information you worked so hard to get
+      or (2) make it impossible for others to access the information you found (this is unacceptable in
+      this exercise, though not in the real world).
+
+      Since some of your changes may be hard for you to undo, you can use the `resetFakeUsers`
+      command to resets all fake user accounts to their initial states and also resets other parts of the
+      system (e.g. deletes all files in the /tmp directory). 
+
+      Executing this command should solve all reseting issues; if it does not, please let us know. By calling resetFakeUsers frequently, you
+      could cause a denial of service attack against your classmates; please do not do this!
+       
+      ## User Secrets
+      Each secret is contained somewhere in that user's home directory. All fake users belong to a
+      group named student, a fact that is important for some of the attacks. There are other significant
+      groups as well that some of these users are in.
+
+      There is no strict sequential order for finding the secrets, though some you will only be able to
+      get after gaining access to another user's account. Password cracking is a great place to start.
+      We will walk you through that below.
+
+       
+      ## Password Cracking:
+
+      For password cracking download [John the Ripper](http://www.openwall.com/john/) onto a
+      local computer. John the Ripper is not on the Treasure Hunt container, and you won't be able to install
+      it there. 
+
+      If you only have access to a Windows computer for your local machine, John the Ripper
+      suggests HashSuite; though we won't provide you with instructions on how to use that program.
+
+      On the Treasure Hunt mcontainer, gain access to the file /etc/shadow. (See hints below if stuck).
+      You will need a copy of /etc/shadow and /etc/passwd on your machine running John the Ripper.
+
+      Next, use John’s unshadow command to combine /etc/passwd and /etc/shadow into a single
+      password file (e.g. ‘'unshadow passwd shadow > mypasswd’).
+      Manually edit 'mypasswd' to exclude all accounts other than the 16 fake users for this problem —
+      otherwise you’re wasting processing time in your password cracker. 
+
+      When you find the secret of a fake user, removing that user from the unshadowed file will help speed up future attempts.
+      You do not want to waste processing time trying to crack passwords you don’t need!
+
+      Run John on 'mypasswd' (e.g. ‘john passwords’). The basic john command uses the default
+      wordlist run/password.Ist, which should be able to fairly quickly crack two user passwords.
+      There is one more password that can be cracked, but you will need to feed john a custom word
+      list. Maybe if you Knew more about fake users...
+
+
+      ## User Web Pages:
+      Each user has at least one web page in a public html directory. Some of these pages contain
+      information relevant to finding their secret. Although many of the user web pages are publicly
+      readable by any user on the THVM, some can only be read via a web browser. 
+
+      Since you are logged in via ssh, you might be wondering how you can view these web pages. 
+      Lynx is a textbased web browser that we have provided for your use. Typing `lynx localhost/~awan/` will let
+      you view awan's homepage. The same format can be used to view the other 15 user's pages.
+
+      Though you can see the public html pages in each user's directory, due to the permissions of
+      any private files, you will need to use Lynx to uncover some of the secrets. See Lynx's man
+      page for specific instructions. 
+
+      `wget` and `curl` are also good alternative tools, since Lynx may not show you everything...
+
+      ## Other Hints:
+      - It may be helpful to export certain files from the THVM to your local computer (or vice versa).
+        You can use scp or ftp from your local computer to do this.
+        
+      - Having trouble gaining access to /etc/shadow? Look in /bin/ and see if you can find something
+        to help you.
+        
+      - Access to web directories can be controlled by a .htaccess file. See
+        http://www.javascriptkit.com/howto/htaccess.shtml for documentation on .htaccess files.
+        
+      - The web server runs as user/group www-data. Including www-data in a group gives the web
+        server whatever permissions are given to the group. There is a group named apache whose
+        only member is www-data.
+        
+      - In an HTML file, text between <!-- and > is a comment that is not displayed by the web
+        browser.
+        
+      - The utility `pdftotext` is installed for reading pdf files in the console. Alternatively, you may want to export relevant
+        .pdf files from the THVM to your local computer and view them there.)
+        
+      - It is possible to convert .pdf files to other file formats, and there are programs in the THVM for
+        doing this. But saying exactly what those programs are would make one secret too easy too
+        find. So you might want to research how to convert .pdf files to other formats in Linux.
+        
+      - .docx format is a zipped (compressed) directory of XML files; it can be uncompressed with the
+        unzip command. There are many ways to obtain that secret though.
+        
+      - If you want to add a directory dir to the front of your PATH variable, a good way to do this is
+        with the following command - export PATH= dir :$PATH (e.g. ‘export PATH=/tmp/:$PATH’)
+        
+      - The strings command could be helpful for some secrets. As well as a hex viewer.
+
+  Question1: &question1
+    question_num: 1
+    type: question
+    content: Who is the author of awan's quote?
+    answers:
+    - answer_type: String
+      value: Woody Allen
+      points_possible: 20
+    points_possible: 20
+  Question2: &question2
+    question_num: 2
+    type: question
+    content: Who is the author of bduomo's quote?
+    answers:
+    - answer_type: String
+      value: Robert Benchley
+      points_possible: 5
+    points_possible: 5
+  Question3: &question3
+    question_num: 3
+    type: question
+    content: Who is the author of cdry's quote?
+    answers:
+    - answer_type: String
+      value: Benjamin Franklin
+      points_possible: 20
+    points_possible: 20
+  Question4: &question4
+    question_num: 4
+    type: question
+    content: Who is the author of dshi's quote?
+    answers:
+    - answer_type: String
+      value: Orson Welles
+      points_possible: 15
+    points_possible: 15
+  Question5: &question5
+    question_num: 5
+    type: question
+    content: From what country is the proverb of equintu's quote?
+    answers:
+    - answer_type: String
+      value: China
+      points_possible: 5
+    points_possible: 5
+  Question6: &question6
+    question_num: 6
+    type: question
+    content: What is the last word in fsexon's quote?
+    answers:
+    - answer_type: String
+      value: man
+      points_possible: 10
+    points_possible: 10
+  Question7: &question7
+    question_num: 7
+    type: question
+    content: From what country is the proverb of ghepta's quote?
+    answers:
+    - answer_type: String
+      value: Japan
+      points_possible: 15
+    points_possible: 15
+  Question8: &question8
+    question_num: 8
+    type: question
+    content: Who is the author of hochoa's quote?
+    answers:
+    - answer_type: String
+      value: Robert Frost
+      points_possible: 15
+    points_possible: 15
+  Question9: &question9
+    question_num: 9
+    type: question
+    content: Who is the author of inunez's quote?
+    answers:
+    - answer_type: String
+      value: Mark Twain
+      points_possible: 15
+    points_possible: 15
+  Question10: &question10
+    question_num: 10
+    type: question
+    content: Who is the author of jdekka's quote?
+    answers:
+    - answer_type: String
+      value: Ellen DeGeneres
+      points_possible: 5
+    points_possible: 5
+  Question11: &question11
+    question_num: 11
+    type: question
+    content: Who is the author of kelva's quote?
+    answers:
+    - answer_type: String
+      value: P. G. Wodehouse
+      points_possible: 15
+    points_possible: 15
+  Question12: &question12
+    question_num: 12
+    type: question
+    content: Who is the author of ldouzette's quote?
+    answers:
+    - answer_type: String
+      value: Norm Crosby
+      points_possible: 10
+    points_possible: 10
+  Question13: &question13
+    question_num: 13
+    type: question
+    content: Who is the author of pkaideka's quote?
+    answers:
+    - answer_type: String
+      value: Max Lerner
+      points_possible: 10
+    points_possible: 10
+  Question14: &question14
+    question_num: 14
+    type: question
+    content: Who is the author of pradessime's quote?
+    answers:
+    - answer_type: String
+      value: George Burns
+      points_possible: 25
+    points_possible: 25
+  Question15: &question15
+    question_num: 15
+    type: question
+    content: Who is the author of qsanera's quote?
+    answers:
+    - answer_type: String
+      value: Mark Twain
+      points_possible: 10
+    points_possible: 10
+  Question16: &question16
+    question_num: 16
+    type: question
+    content: Who is the author of tdaforth's quote?
+    answers:
+    - answer_type: String
+      value: Erma Bombeck
+      points_possible: 15
+    points_possible: 15
+
+studentGuide:
+  chapters:
+    - chapter_num: 1
+      title: Introduction
+      content_array:
+          - *reading1
+
+    - chapter_num: 2
+      title: Exercises
+      content_array:
+          - *question1
+          - *question2
+          - *question3
+          - *question4
+          - *question5
+          - *question6
+          - *question7
+          - *question8
+          - *question9
+          - *question10
+          - *question11
+          - *question12
+          - *question13
+          - *question14
+          - *question15
+          - *question16

--- a/scenarios/prod/web_fu/guide_content.yml
+++ b/scenarios/prod/web_fu/guide_content.yml
@@ -1,0 +1,189 @@
+ScenarioTitle: Web Fu
+
+contentDefinitions:
+  Reading1: &reading1
+    type: reading
+    content: |
+      ## Learning objectives
+      1. Exploit vulnerable web pages using SQL injection
+      2. Retrieve information from other tables using the `UNION` operator
+      3. Bypass simple WAFs (Web Application Firewall)
+      4. Exploit vulnerable web pages using XSS (Cross-Site-Scripting)
+
+  Reading2: &reading2
+    type: reading
+    content: |
+      ## Connection Instructions
+
+      You can find the vulnerable webapp at port 8443 of the EDURange platform.
+
+  Reading3: &reading3
+    type: reading
+    content: |
+      ## Extra Resources
+      [OWASP SQLi Guide](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/05-Testing_for_SQL_Injection.html)
+
+      [PortSwigger SQL Guide](https://portswigger.net/web-security/sql-injection)
+
+  Reading4: &reading4
+    type: reading
+    content: |
+      ## Exercises
+
+      ### Level 1 (SQL-1.php)
+      The query being run on this page is:
+
+      `SELECT * FROM countries WHERE name='<ARG>';`
+
+      <question>
+      <question>
+      <question>
+
+      ### Level 2 (SQL-2.php)
+      The query being run on this page is:
+
+      `SELECT * FROM books WHERE author LIKE '%<ARG>%';`
+
+      <question>
+      <question>
+      <question>
+
+      ### Level 3 (SQL-3.php)
+
+      Hint: First find a way to count the number of columns in the table
+
+      <question>
+      <question>
+
+      ### Level 4 (XSS-reflected-1.php)
+
+      [Hint](https://edurange.watzek.cloud:8443/XSS-reflected-1.php?parameter=value)
+
+      <question>
+
+      ### Level 5 (XSS-reflected-2.php)
+
+      Look at the source.
+
+      <question>
+
+      ### Level 6 (XSS-stored-1.php)
+
+      <question>
+
+
+question1: &question1
+  question_num: 1
+  content: Which database engine is being used in this scenario? SQLite, PostgreSQL, MongoDB, etc.
+  options: []
+  answers:
+    - answer_type: String
+      value: MySQL
+      points_possible: 5
+  points_possible: 5
+
+question2: &question2
+  question_num: 2
+  content: What are the 3 different types of "comment" symbol in this database type?
+  options: []
+  answers:
+    - answer_type: String
+      value: '--'
+      points_possible: 5
+    - answer_type: String
+      value: '#'
+      points_possible: 5
+    - answer_type: String
+      value: '/**/'
+      points_possible: 5
+  points_possible: 15
+
+- Text: What symbol is used to mark the end of a query?
+  Type: String
+  Options: []
+  Answers:
+  - Value: ';'
+    Points: 5
+  - Value: semicolon
+    Points: 5
+  Points: 5
+- Text: What technique could be used to avoid these types of SQL injection?
+  Type: String
+  Options: []
+  Answers:
+  - Value: query parameterization
+    Points: 5
+  - Value: prepared statements
+    Points: 5
+  Points: 5
+- Text: What programming language is the scenario website built with?
+  Type: String
+  Answers:
+  - Value: PHP
+    Points: 5
+  Points: 5
+- Text: What boolean operator did you use to dump the table from level 1?
+  Type: String
+  Answers:
+  - Value: OR
+    Points: 15
+  Points: 15
+- Text: What is the flag for level 1 (SQL-1.php)?
+  Type: String
+  Answers:
+  - Value: FLAG{1NJ3CT10NS_4R3_N1C3!}
+    Points: 15
+  Points: 15
+- Text: What special character is the LIKE query using in level 2?
+  Type: String
+  Answers:
+  - Value: '%'
+    Points: 15
+  Points: 15
+- Text: What is the flag for level 2 (SQL-2.php)?
+  Type: String
+  Answers:
+  - Value: FLAG{Y0U_D0_L1K3_QU3R13S}
+    Points: 20
+  Points: 20
+- Text: What keyword could you use to query two combined tables?
+  Type: String
+  Answers:
+  - Value: UNION
+    Points: 10
+  Points: 10
+- Text: What is the flag for level 3 (SQL-3.php)?
+  Type: String
+  Answers:
+  - Value: FLAG{1M_N0T_4_H4SH3D_H4X0R}
+    Points: 25
+  Points: 25
+- Text: What is the password for user "backdoor"?
+  Type: String
+  Answers:
+  - Value: supersecreto
+    Points: 30
+  Points: 30
+- Text: What is the flag for level 4 (XSS-reflected-1.php)?
+  Type: String
+  Answers:
+  - Value: FLAG{4LW4Y5_54N71Z3_1NPU7}
+    Points: 15
+  Points: 15
+- Text: What is the flag for level 5 (XSS-reflected-2.php)?
+  Type: String
+  Answers:
+  - Value: FLAG{0NSUCC3SS_4L3R7(PWN)}
+    Points: 20
+  Points: 20
+- Text: What is the flag for level 6 (XSS-stored-1.php)?
+  Type: String
+  Answers:
+  - Value: FLAG{P4YL04D_1NJ3CT3D}
+    Points: 20
+  Points: 20
+
+
+
+
+

--- a/scenarios/prod/web_fu/guide_content.yml
+++ b/scenarios/prod/web_fu/guide_content.yml
@@ -28,8 +28,6 @@ contentDefinitions:
   Reading4: &reading4
     type: reading
     content: |
-      ## Exercises
-
       ### Level 1 (SQL-1.php)
       The query being run on this page is:
 
@@ -39,6 +37,9 @@ contentDefinitions:
       <question>
       <question>
 
+  Reading5: &reading5
+    type: reading
+    content: |
       ### Level 2 (SQL-2.php)
       The query being run on this page is:
 
@@ -48,6 +49,9 @@ contentDefinitions:
       <question>
       <question>
 
+  Reading6: &reading6
+    type: reading
+    content: |
       ### Level 3 (SQL-3.php)
 
       Hint: First find a way to count the number of columns in the table
@@ -55,135 +59,209 @@ contentDefinitions:
       <question>
       <question>
 
+  Reading7: &reading7
+    type: reading
+    content: |
       ### Level 4 (XSS-reflected-1.php)
 
       [Hint](https://edurange.watzek.cloud:8443/XSS-reflected-1.php?parameter=value)
 
       <question>
 
+  Reading8: &reading8
+    type: reading
+    content: |
       ### Level 5 (XSS-reflected-2.php)
 
       Look at the source.
 
       <question>
 
+  Reading9: &reading9
+    type: reading
+    content: |
       ### Level 6 (XSS-stored-1.php)
 
       <question>
 
-
-question1: &question1
-  question_num: 1
-  content: Which database engine is being used in this scenario? SQLite, PostgreSQL, MongoDB, etc.
-  options: []
-  answers:
+  Question1: &question1
+    question_num: 1
+    type: question
+    content: Which database engine is being used in this scenario? SQLite, PostgreSQL,
+      MongoDB, etc.
+    answers:
     - answer_type: String
       value: MySQL
       points_possible: 5
-  points_possible: 5
-
-question2: &question2
-  question_num: 2
-  content: What are the 3 different types of "comment" symbol in this database type?
-  options: []
-  answers:
-    - answer_type: String
-      value: '--'
+    points_possible: 5
+  Question2: &question2
+    question_num: 2
+    type: question
+    content: What are the 3 different types of "comment" symbol in this database type?
+    answers:
+    - answer_type: Multi String
+      value: --
       points_possible: 5
-    - answer_type: String
+    - answer_type: Multi String
       value: '#'
       points_possible: 5
-    - answer_type: String
-      value: '/**/'
+    - answer_type: Multi String
+      value: /**/
       points_possible: 5
-  points_possible: 15
+    points_possible: 15
+  Question3: &question3
+    question_num: 3
+    type: question
+    content: What symbol is used to mark the end of a query?
+    answers:
+    - answer_type: String
+      value: ;
+      points_possible: 5
+    - answer_type: String
+      value: semicolon
+      points_possible: 5
+    points_possible: 5
+  Question4: &question4
+    question_num: 4
+    type: question
+    content: What technique could be used to avoid these types of SQL injection?
+    answers:
+    - answer_type: String
+      value: query parameterization
+      points_possible: 5
+    - answer_type: String
+      value: prepared statements
+      points_possible: 5
+    points_possible: 5
+  Question5: &question5
+    question_num: 5
+    type: question
+    content: What programming language is the scenario website built with?
+    answers:
+    - answer_type: String
+      value: PHP
+      points_possible: 5
+    points_possible: 5
+  Question6: &question6
+    question_num: 6
+    type: question
+    content: What boolean operator did you use to dump the table from level 1?
+    answers:
+    - answer_type: String
+      value: OR
+      points_possible: 15
+    points_possible: 15
+  Question7: &question7
+    question_num: 7
+    type: question
+    content: What is the flag for level 1 (SQL-1.php)?
+    answers:
+    - answer_type: String
+      value: FLAG{1NJ3CT10NS_4R3_N1C3!}
+      points_possible: 15
+    points_possible: 15
+  Question8: &question8
+    question_num: 8
+    type: question
+    content: What special character is the LIKE query using in level 2?
+    answers:
+    - answer_type: String
+      value: '%'
+      points_possible: 15
+    points_possible: 15
+  Question9: &question9
+    question_num: 9
+    type: question
+    content: What is the flag for level 2 (SQL-2.php)?
+    answers:
+    - answer_type: String
+      value: FLAG{Y0U_D0_L1K3_QU3R13S}
+      points_possible: 20
+    points_possible: 20
+  Question10: &question10
+    question_num: 10
+    type: question
+    content: What keyword could you use to query two combined tables?
+    answers:
+    - answer_type: String
+      value: UNION
+      points_possible: 10
+    points_possible: 10
+  Question11: &question11
+    question_num: 11
+    type: question
+    content: What is the flag for level 3 (SQL-3.php)?
+    answers:
+    - answer_type: String
+      value: FLAG{1M_N0T_4_H4SH3D_H4X0R}
+      points_possible: 25
+    points_possible: 25
+  Question12: &question12
+    question_num: 12
+    type: question
+    content: What is the password for user "backdoor"?
+    answers:
+    - answer_type: String
+      value: supersecreto
+      points_possible: 30
+    points_possible: 30
+  Question13: &question13
+    question_num: 13
+    type: question
+    content: What is the flag for level 4 (XSS-reflected-1.php)?
+    answers:
+    - answer_type: String
+      value: FLAG{4LW4Y5_54N71Z3_1NPU7}
+      points_possible: 15
+    points_possible: 15
+  Question14: &question14
+    question_num: 14
+    type: question
+    content: What is the flag for level 5 (XSS-reflected-2.php)?
+    answers:
+    - answer_type: String
+      value: FLAG{0NSUCC3SS_4L3R7(PWN)}
+      points_possible: 20
+    points_possible: 20
+  Question15: &question15
+    question_num: 15
+    type: question
+    content: What is the flag for level 6 (XSS-stored-1.php)?
+    answers:
+    - answer_type: String
+      value: FLAG{P4YL04D_1NJ3CT3D}
+      points_possible: 20
+    points_possible: 20
 
-- Text: What symbol is used to mark the end of a query?
-  Type: String
-  Options: []
-  Answers:
-  - Value: ';'
-    Points: 5
-  - Value: semicolon
-    Points: 5
-  Points: 5
-- Text: What technique could be used to avoid these types of SQL injection?
-  Type: String
-  Options: []
-  Answers:
-  - Value: query parameterization
-    Points: 5
-  - Value: prepared statements
-    Points: 5
-  Points: 5
-- Text: What programming language is the scenario website built with?
-  Type: String
-  Answers:
-  - Value: PHP
-    Points: 5
-  Points: 5
-- Text: What boolean operator did you use to dump the table from level 1?
-  Type: String
-  Answers:
-  - Value: OR
-    Points: 15
-  Points: 15
-- Text: What is the flag for level 1 (SQL-1.php)?
-  Type: String
-  Answers:
-  - Value: FLAG{1NJ3CT10NS_4R3_N1C3!}
-    Points: 15
-  Points: 15
-- Text: What special character is the LIKE query using in level 2?
-  Type: String
-  Answers:
-  - Value: '%'
-    Points: 15
-  Points: 15
-- Text: What is the flag for level 2 (SQL-2.php)?
-  Type: String
-  Answers:
-  - Value: FLAG{Y0U_D0_L1K3_QU3R13S}
-    Points: 20
-  Points: 20
-- Text: What keyword could you use to query two combined tables?
-  Type: String
-  Answers:
-  - Value: UNION
-    Points: 10
-  Points: 10
-- Text: What is the flag for level 3 (SQL-3.php)?
-  Type: String
-  Answers:
-  - Value: FLAG{1M_N0T_4_H4SH3D_H4X0R}
-    Points: 25
-  Points: 25
-- Text: What is the password for user "backdoor"?
-  Type: String
-  Answers:
-  - Value: supersecreto
-    Points: 30
-  Points: 30
-- Text: What is the flag for level 4 (XSS-reflected-1.php)?
-  Type: String
-  Answers:
-  - Value: FLAG{4LW4Y5_54N71Z3_1NPU7}
-    Points: 15
-  Points: 15
-- Text: What is the flag for level 5 (XSS-reflected-2.php)?
-  Type: String
-  Answers:
-  - Value: FLAG{0NSUCC3SS_4L3R7(PWN)}
-    Points: 20
-  Points: 20
-- Text: What is the flag for level 6 (XSS-stored-1.php)?
-  Type: String
-  Answers:
-  - Value: FLAG{P4YL04D_1NJ3CT3D}
-    Points: 20
-  Points: 20
 
+studentGuide:
+  chapters:
+    - chapter_num: 1
+      title: Introduction
+      content_array:
+        - *reading1
+        - *reading2
+        - *reading3
 
-
+    - chapter_num: 2
+      title: Exercises
+      content_array:
+        - *reading4
+        - *question1
+        - *question2
+        - *question3
+        - *reading5
+        - *question4
+        - *question5
+        - *question6
+        - *reading6
+        - *question7
+        - *question8
+        - *reading7
+        - *question9
+        - *reading8
+        - *question10
+        - *reading9
+        - *question11
 
 


### PR DESCRIPTION
Converted guides for Webfu, Metasploitable, and Treasure hunt.

I followed the previous order of readings and questions defined in `studentview/content.json` but I think webfu specifically should be reviewed. I think only 11 of the 15 questions are used and I'm not confident they are in the right order.

Metasploitable runs but the ssh connection puts the user on target instead of attacker.

Also added placeholder guides for Ransomware and Elf Infection so the scenarios can atleast load.
Although student users seem to not be added to the NAT container for Elf Infection. I believe this is because of a file provision error in terraform during remote execution.