### PR TITLE
rename nat to StartingLine WIP

### DIFF
--- a/py_flask/utils/tasks.py
+++ b/py_flask/utils/tasks.py
@@ -152,7 +152,7 @@ def start_scenario_task(self, scenario_id):
         name = str(scenario.name)
         name = "".join(e for e in name if e.isalnum())
         gateway = name + "_gateway"
-        start = name + "_nat"
+        start = name + "_StartingLine"
         start_ip = "10." + str(scenario.octet) + ".0.2"
         if int(scenario.status) != 0:
             logger.info("Invalid Status")

--- a/scenarios/prod/elf_infection/StartingLine.tf.json
+++ b/scenarios/prod/elf_infection/StartingLine.tf.json
@@ -3,7 +3,7 @@
     {
       "docker_container": [
         {
-          "SNAME_nat": [
+          "SNAME_StartingLine": [
             {
               "capabilities": [
                 {
@@ -26,9 +26,9 @@
                   "user": "root"
                 }
               ],
-              "hostname": "NAT",
+              "hostname": "StartingLine",
               "image": "edurange2/ubuntu-sshd:16.04",
-              "name": "SNAME_nat",
+              "name": "SNAME_StartingLine",
               "networks_advanced": [
                 {
                   "ipv4_address": "10.OCTET.1.2",
@@ -49,6 +49,7 @@
                   "remote-exec": [
                     {
                       "inline": [
+                        "echo 'export PATH=/usr/special/bin:$PATH' >> /etc/bash.bashrc",
                         "USERS",
                         "EXECS"
                       ]
@@ -65,17 +66,17 @@
   ],
   "locals": [
     {
-      "SNAME_nat_extern": "HIDDEN"
+      "SNAME_StartingLine_extern": "HIDDEN"
     }
   ],
   "output": [
     {
-      "SNAME_nat": [
+      "SNAME_StartingLine": [
         {
           "value": [
             {
-              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_nat_extern])}",
-              "name": "SNAME_nat"
+              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+              "name": "SNAME_StartingLine"
             }
           ]
         }

--- a/scenarios/prod/elf_infection/elf_infection.json
+++ b/scenarios/prod/elf_infection/elf_infection.json
@@ -2,7 +2,7 @@
     "containers": 
     [ 
         {
-            "name" : "nat",
+            "name" : "StartingLine",
             "files": [{
                 "global_files": [
                 ],

--- a/scenarios/prod/file_wrangler/StartingLine.tf.json
+++ b/scenarios/prod/file_wrangler/StartingLine.tf.json
@@ -3,7 +3,7 @@
     {
       "docker_container": [
         {
-          "SNAME_nat": [
+          "SNAME_StartingLine": [
             {
               "capabilities": [
                 {
@@ -26,9 +26,9 @@
                   "user": "root"
                 }
               ],
-              "hostname": "NAT",
+              "hostname": "StartingLine",
               "image": "edurange2/ubuntu-sshd:16.04",
-              "name": "SNAME_nat",
+              "name": "SNAME_StartingLine",
               "networks_advanced": [
                 {
                   "ipv4_address": "10.OCTET.1.2",
@@ -49,7 +49,6 @@
                   "remote-exec": [
                     {
                       "inline": [
-                        "echo 'export PATH=/usr/special/bin:$PATH' >> /etc/bash.bashrc",
                         "USERS",
                         "EXECS"
                       ]
@@ -66,17 +65,17 @@
   ],
   "locals": [
     {
-      "SNAME_nat_extern": "HIDDEN"
+      "SNAME_StartingLine_extern": "HIDDEN"
     }
   ],
   "output": [
     {
-      "SNAME_nat": [
+      "SNAME_StartingLine": [
         {
           "value": [
             {
-              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_nat_extern])}",
-              "name": "SNAME_nat"
+              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+              "name": "SNAME_StartingLine"
             }
           ]
         }

--- a/scenarios/prod/file_wrangler/file_wrangler.json
+++ b/scenarios/prod/file_wrangler/file_wrangler.json
@@ -2,7 +2,7 @@
     "containers": 
     [ 
         {
-            "name" : "nat",
+            "name" : "StartingLine",
             "files": [{
                 "global_files": [
                 ],

--- a/scenarios/prod/getting_started/StartingLine.tf.json
+++ b/scenarios/prod/getting_started/StartingLine.tf.json
@@ -3,7 +3,7 @@
         {
             "docker_container": [
                 {
-                    "SNAME_nat": [
+                    "SNAME_StartingLine": [
                         {
                             "capabilities": [
                                 {
@@ -26,9 +26,9 @@
                                     "user": "root"
                                 }
                             ],
-                            "hostname": "NAT",
-                            "image": "edurange2/webfu:latest",
-                            "name": "SNAME_nat",
+                            "hostname": "StartingLine",
+                            "image": "edurange2/ubuntu-sshd:16.04",
+                            "name": "SNAME_StartingLine",
                             "networks_advanced": [
                                 {
                                     "ipv4_address": "10.OCTET.1.2",
@@ -42,22 +42,8 @@
                             "ports": [
                                 {
                                     "internal": 22
-                                },
-                                {
-                                    "internal": 80,
-                                    "external": 8080
-                                },
-                                {
-                                    "internal": 443,
-                                    "external": 8443
                                 }
                             ],
-                            "mounts": {
-                                "source": "/etc/letsencrypt/archive/EXTERN_HOST",
-                                "target": "/etc/ssl/webfu",
-                                "type": "bind",
-                                "read_only": true
-                            },
                             "provisioner": [
                                 {
                                     "remote-exec": [
@@ -79,17 +65,17 @@
     ],
     "locals": [
         {
-            "SNAME_nat_extern": "HIDDEN"
+            "SNAME_StartingLine_extern": "HIDDEN"
         }
     ],
     "output": [
         {
-            "SNAME_nat": [
+            "SNAME_StartingLine": [
                 {
                     "value": [
                         {
-                            "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_nat_extern])}",
-                            "name": "SNAME_nat"
+                            "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+                            "name": "SNAME_StartingLine"
                         }
                     ]
                 }

--- a/scenarios/prod/getting_started/getting_started.json
+++ b/scenarios/prod/getting_started/getting_started.json
@@ -2,7 +2,7 @@
     "containers":  
     [
         {
-            "name" : "nat",
+            "name" : "StartingLine",
             "files":[
                 {
                     "global_files": [

--- a/scenarios/prod/metasploitable/StartingLine.tf.json
+++ b/scenarios/prod/metasploitable/StartingLine.tf.json
@@ -1,6 +1,6 @@
 {
-	"resource": [
-	{
+    "resource": [
+        {
             "docker_container": [
                 {
                     "SNAME_StartingLine": [
@@ -19,16 +19,16 @@
                             ],
                             "connection": [
                                 {
-                                    "host": "${self.ports[0].ip}",
-                                    "password": "root",
-                                    "port": "${self.ports[0].external}",
-                                    "type": "ssh",
-                                    "user": "root"
+                                  "host": "${self.ports[0].ip}",
+                                  "password": "root",
+                                  "port": "${self.ports[0].external}",
+                                  "type": "ssh",
+                                  "user": "root"
                                 }
                             ],
-                            "hostname": "NAT",
-                            "image": "edurange2/ubuntu-sshd:16.04",
-                            "name": "SNAME_nat",
+                            "hostname": "StartingLine",
+                            "image": "edurange2/metasploit.attacker.dev",
+                            "name": "SNAME_StartingLine",
                             "networks_advanced": [
                                 {
                                     "ipv4_address": "10.OCTET.1.2",
@@ -42,6 +42,12 @@
                             "ports": [
                                 {
                                     "internal": 22
+                                }
+                            ],
+                            "host": [
+                                {
+                                    "host": "target",
+                                    "ip": "10.OCTET.0.2"
                                 }
                             ],
                             "provisioner": [
@@ -61,10 +67,11 @@
                     ]
                 }
             ]
-        }],
+        }
+    ],
     "locals": [
         {
-            "SNAME_StartingLine_extern": "HIDDEN"
+            "SNAME_StartingLine_extern": "${tostring(docker_container.SNAME_StartingLine.ports[0].external)}"
         }
     ],
     "output": [
@@ -73,13 +80,13 @@
                 {
                     "value": [
                         {
-                            "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
-                            "name": "SNAME_StartingLine"
+                          "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+                          "name": "SNAME_StartingLine"
                         }
                     ]
                 }
             ]
         }
     ]
-
 }
+

--- a/scenarios/prod/metasploitable/metasploitable.json
+++ b/scenarios/prod/metasploitable/metasploitable.json
@@ -14,7 +14,7 @@
 		}]
 	},
 	{
-		"name" : "nat",
+		"name" : "StartingLine",
 		"files": [{
 			"global_files": [
 			],

--- a/scenarios/prod/metasploitable/target.tf.json
+++ b/scenarios/prod/metasploitable/target.tf.json
@@ -31,11 +31,11 @@
                             "name": "SNAME_target",
                             "networks_advanced": [
                                 {
-                                    "ipv4_address": "10.OCTET.1.2",
+                                    "ipv4_address": "10.OCTET.1.3",
                                     "name": "SNAME_NAT"
                                 },
                                 {
-                                    "ipv4_address": "10.OCTET.0.2",
+                                    "ipv4_address": "10.OCTET.0.3",
                                     "name": "SNAME_PLAYER"
                                 }
                             ],

--- a/scenarios/prod/ransomware/ransom.tf.json
+++ b/scenarios/prod/ransomware/ransom.tf.json
@@ -27,7 +27,7 @@
               ],
               "hostname": "ransom",
               "image": "edurange2/ubuntu_desktop_testing",
-              "name": "SNAME_nat",
+              "name": "SNAME_ransom",
               "networks_advanced": [
                 {
                   "ipv4_address": "10.OCTET.1.2",

--- a/scenarios/prod/ssh_inception/StartingLine.tf.json
+++ b/scenarios/prod/ssh_inception/StartingLine.tf.json
@@ -1,9 +1,9 @@
 {
-    "resource": [
-        {
+	"resource": [
+	{
             "docker_container": [
                 {
-                    "SNAME_nat": [
+                    "SNAME_StartingLine": [
                         {
                             "capabilities": [
                                 {
@@ -26,9 +26,9 @@
                                     "user": "root"
                                 }
                             ],
-                            "hostname": "NAT",
+                            "hostname": "StartingLine",
                             "image": "edurange2/ubuntu-sshd:16.04",
-                            "name": "SNAME_nat",
+                            "name": "SNAME_StartingLine",
                             "networks_advanced": [
                                 {
                                     "ipv4_address": "10.OCTET.1.2",
@@ -61,25 +61,25 @@
                     ]
                 }
             ]
-        }
-    ],
+        }],
     "locals": [
         {
-            "SNAME_nat_extern": "HIDDEN"
+            "SNAME_StartingLine_extern": "HIDDEN"
         }
     ],
     "output": [
         {
-            "SNAME_nat": [
+            "SNAME_StartingLine": [
                 {
                     "value": [
                         {
-                            "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_nat_extern])}",
-                            "name": "SNAME_nat"
+                            "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+                            "name": "SNAME_StartingLine"
                         }
                     ]
                 }
             ]
         }
     ]
+
 }

--- a/scenarios/prod/ssh_inception/ssh_inception.json
+++ b/scenarios/prod/ssh_inception/ssh_inception.json
@@ -1,7 +1,7 @@
 {
    "containers":[
       {
-         "name":"nat",
+         "name":"StartingLine",
          "files":[
             {
                "global_files":[

--- a/scenarios/prod/strace/StartingLine.tf.json
+++ b/scenarios/prod/strace/StartingLine.tf.json
@@ -3,7 +3,7 @@
     {
       "docker_container": [
         {
-          "SNAME_nat": [
+          "SNAME_StartingLine": [
             {
               "capabilities": [
                 {
@@ -26,9 +26,9 @@
                   "user": "root"
                 }
               ],
-              "hostname": "NAT",
+              "hostname": "StartingLine",
               "image": "edurange2/ubuntu-sshd:16.04",
-              "name": "SNAME_nat",
+              "name": "SNAME_StartingLine",
               "networks_advanced": [
                 {
                   "ipv4_address": "10.OCTET.1.2",
@@ -65,17 +65,17 @@
   ],
   "locals": [
     {
-      "SNAME_nat_extern": "HIDDEN"
+      "SNAME_StartingLine_extern": "HIDDEN"
     }
   ],
   "output": [
     {
-      "SNAME_nat": [
+      "SNAME_StartingLine": [
         {
           "value": [
             {
-              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_nat_extern])}",
-              "name": "SNAME_nat"
+              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+              "name": "SNAME_StartingLine"
             }
           ]
         }

--- a/scenarios/prod/strace/guide_content.yml
+++ b/scenarios/prod/strace/guide_content.yml
@@ -240,7 +240,7 @@ contentDefinitions:
     content: What is the secret Flag obtained by tracing script.sh? (The inner contents of FLAG{...})
     answers:
       - answer_type: String
-        value: $RANDOM_ONE
+        value: $RANDOM
         points_possible: 10
     points_possible: 10
 

--- a/scenarios/prod/strace/strace.json
+++ b/scenarios/prod/strace/strace.json
@@ -2,7 +2,7 @@
     "containers": 
     [ 
         {
-            "name" : "nat",
+            "name" : "StartingLine",
             "files": [{
                 "global_files": [
                     "cat",

--- a/scenarios/prod/total_recon/StartingLine.tf.json
+++ b/scenarios/prod/total_recon/StartingLine.tf.json
@@ -3,7 +3,7 @@
     {
       "docker_container": [
         {
-          "SNAME_nat": [
+          "SNAME_StartingLine": [
             {
               "capabilities": [
                 {
@@ -26,9 +26,9 @@
                   "user": "root"
                 }
               ],
-              "hostname": "NAT",
+              "hostname": "StartingLine",
               "image": "edurange2/ubuntu-sshd:16.04",
-              "name": "SNAME_nat",
+              "name": "SNAME_StartingLine",
               "networks_advanced": [
                 {
                   "ipv4_address": "10.OCTET.1.2",
@@ -64,17 +64,17 @@
     }],
   "locals": [
     {
-      "SNAME_nat_extern": "HIDDEN"
+      "SNAME_StartingLine_extern": "HIDDEN"
     }
   ],
   "output": [
     {
-      "SNAME_nat": [
+      "SNAME_StartingLine": [
         {
           "value": [
             {
-              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_nat_extern])}",
-              "name": "SNAME_nat"
+              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+              "name": "SNAME_StartingLine"
             }
           ]
         }

--- a/scenarios/prod/total_recon/total_recon.json
+++ b/scenarios/prod/total_recon/total_recon.json
@@ -1,7 +1,7 @@
 {
   "containers":[
     {
-      "name":"nat",
+      "name":"StartingLine",
       "files":[
         {
           "global_files":[

--- a/scenarios/prod/treasure_hunt/StartingLine.tf.json
+++ b/scenarios/prod/treasure_hunt/StartingLine.tf.json
@@ -3,7 +3,7 @@
     {
       "docker_container": [
         {
-          "SNAME_nat": [
+          "SNAME_StartingLine": [
             {
               "capabilities": [
                 {
@@ -26,9 +26,9 @@
                   "user": "root"
                 }
               ],
-              "hostname": "NAT",
+              "hostname": "StartingLine",
               "image": "edurange2/ubuntu-sshd:16.04",
-              "name": "SNAME_nat",
+              "name": "SNAME_StartingLine",
               "networks_advanced": [
                 {
                   "ipv4_address": "10.OCTET.1.2",
@@ -65,17 +65,17 @@
   ],
   "locals": [
     {
-      "SNAME_nat_extern": "HIDDEN"
+      "SNAME_StartingLine_extern": "HIDDEN"
     }
   ],
   "output": [
     {
-      "SNAME_nat": [
+      "SNAME_StartingLine": [
         {
           "value": [
             {
-              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_nat_extern])}",
-              "name": "SNAME_nat"
+              "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+              "name": "SNAME_StartingLine"
             }
           ]
         }

--- a/scenarios/prod/treasure_hunt/treasure_hunt.json
+++ b/scenarios/prod/treasure_hunt/treasure_hunt.json
@@ -2,7 +2,7 @@
     "containers": 
     [ 
         {
-            "name" : "nat",
+            "name" : "StartingLine",
             "files": [{
                 "global_files": [
                 ],

--- a/scenarios/prod/web_fu/StartingLine.tf.json
+++ b/scenarios/prod/web_fu/StartingLine.tf.json
@@ -3,7 +3,7 @@
         {
             "docker_container": [
                 {
-                    "SNAME_attacker": [
+                    "SNAME_StartingLine": [
                         {
                             "capabilities": [
                                 {
@@ -19,37 +19,45 @@
                             ],
                             "connection": [
                                 {
-                                  "host": "${self.ports[0].ip}",
-                                  "password": "root",
-                                  "port": "${self.ports[0].external}",
-                                  "type": "ssh",
-                                  "user": "root"
+                                    "host": "${self.ports[0].ip}",
+                                    "password": "root",
+                                    "port": "${self.ports[0].external}",
+                                    "type": "ssh",
+                                    "user": "root"
                                 }
                             ],
-                            "hostname": "attacker",
-                            "image": "edurange2/metasploit.attacker.dev",
-                            "name": "SNAME_attacker",
+                            "hostname": "StartingLine",
+                            "image": "edurange2/webfu:latest",
+                            "name": "SNAME_StartingLine",
                             "networks_advanced": [
                                 {
-                                    "ipv4_address": "10.OCTET.1.3",
+                                    "ipv4_address": "10.OCTET.1.2",
                                     "name": "SNAME_NAT"
                                 },
                                 {
-                                    "ipv4_address": "10.OCTET.0.3",
+                                    "ipv4_address": "10.OCTET.0.2",
                                     "name": "SNAME_PLAYER"
                                 }
                             ],
                             "ports": [
                                 {
                                     "internal": 22
-                                }
-                            ],
-                            "host": [
+                                },
                                 {
-                                    "host": "target",
-                                    "ip": "10.OCTET.0.2"
+                                    "internal": 80,
+                                    "external": 8080
+                                },
+                                {
+                                    "internal": 443,
+                                    "external": 8443
                                 }
                             ],
+                            "mounts": {
+                                "source": "/etc/letsencrypt/archive/EXTERN_HOST",
+                                "target": "/etc/ssl/webfu",
+                                "type": "bind",
+                                "read_only": true
+                            },
                             "provisioner": [
                                 {
                                     "remote-exec": [
@@ -71,17 +79,17 @@
     ],
     "locals": [
         {
-            "SNAME_attacker_extern": "${tostring(docker_container.SNAME_attacker.ports[0].external)}"
+            "SNAME_StartingLine_extern": "HIDDEN"
         }
     ],
     "output": [
         {
-            "SNAME_attacker": [
+            "SNAME_StartingLine": [
                 {
                     "value": [
                         {
-                          "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_attacker_extern])}",
-                          "name": "SNAME_attacker"
+                            "ip_address_public": "${join(\":\", [\"EXTERN_HOST\", local.SNAME_StartingLine_extern])}",
+                            "name": "SNAME_StartingLine"
                         }
                     ]
                 }
@@ -89,4 +97,3 @@
         }
     ]
 }
-

--- a/shell_scripts/clear_scenarios.sh
+++ b/shell_scripts/clear_scenarios.sh
@@ -6,6 +6,7 @@ if [ "$#" -ne 1 ]; then
     echo "Usage: './clear_scenarios.sh <database_name>'"
 fi
 
+sudo -u postgres -H -- psql -d $DATABASE_NAME -c "DELETE FROM bash_history"
 sudo -u postgres -H -- psql -d $DATABASE_NAME -c "DELETE FROM responses"
 sudo -u postgres -H -- psql -d $DATABASE_NAME -c "DELETE FROM scenario_groups"
 sudo -u postgres -H -- psql -d $DATABASE_NAME -c "DELETE FROM scenarios"


### PR DESCRIPTION
Tested all scenarios except ransomware.

What still needs to be done: renaming the `motd_nat` file in each scenario and renaming the corresping entry in
`<scenario>.json`.

Some things I noticed:

pretty often scenarios cannot be destroyed, I believe it is if they have any bash history at all the destroy button does nothing. Ill create and issue for that.

strace builds succesfully and I am able to login as a user but the scenario files are not in my home directory. I think this is because the install script fails expecting an argument passed to it and for some reason one is not being passed.
terraform error:
```
 /home/ubuntu/install: line 11: $1: unbound variable
```