### PR TITLE
Updating metasploit to follow existing loop function, other logging changes

### DIFF
--- a/py_flask/utils/scenario_utils.py
+++ b/py_flask/utils/scenario_utils.py
@@ -18,7 +18,7 @@ file_handler.setLevel(logging.INFO)
 
 # Create a console handler
 console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.INFO)
+console_handler.setLevel(logging.WARNING)
 
 # Create a formatter
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')

--- a/py_flask/utils/tasks.py
+++ b/py_flask/utils/tasks.py
@@ -33,7 +33,7 @@ file_handler.setLevel(logging.INFO)
 
 # Create a console handler
 console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.INFO)
+console_handler.setLevel(logging.WARNING)
 
 # Create a formatter
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')

--- a/py_flask/utils/terraform_utils.py
+++ b/py_flask/utils/terraform_utils.py
@@ -15,7 +15,7 @@ file_handler.setLevel(logging.INFO)
 
 # Create a console handler
 console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.INFO)
+console_handler.setLevel(logging.WARNING)
 
 # Create a formatter
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')

--- a/scenarios/prod/metasploitable/container/StartingLine.tf.json
+++ b/scenarios/prod/metasploitable/container/StartingLine.tf.json
@@ -71,7 +71,7 @@
     ],
     "locals": [
         {
-            "SNAME_StartingLine_extern": "${tostring(docker_container.SNAME_StartingLine.ports[0].external)}"
+            "SNAME_StartingLine_extern": "HIDDEN"
         }
     ],
     "output": [

--- a/scenarios/prod/metasploitable/container/target.tf.json
+++ b/scenarios/prod/metasploitable/container/target.tf.json
@@ -71,7 +71,7 @@
     ],
     "locals": [
         {
-            "SNAME_target_extern": "${tostring(docker_container.SNAME_target.ports[0].external)}"
+            "SNAME_target_extern": "HIDDEN"
         }
     ],
     "output": [


### PR DESCRIPTION
**1. Why is this change being made?**
- Results of a deep dive on metasploit intermittently posting the incorrect port to the react dashboard

**2. What has changed?**
- Main changes are modifying the `StartingLine.tf.json` and `target.tf.json` to HIDDEN for the ports to not be included in the loop function line 143 of scenario_routes.py.
- Log changes are modify the console output of three main py_flask utils from INFO to warning to reduce logging std output.

**3. Are there any issue or concerns?**
- As discussed in today's meeting, Tuesday 24 Sept, the loop function should be modified to be more intentional. Need to change this to filter for 'gateway' and not HIDDEN (if it exists in the ssh_connections keys).

**4. Any related PRs or CRs?** 
- #73 

**5. How was this tested.**

- Tested on branch terraform_update with `npm run dev`, started scenario on the dashboard and monitored the console, used the dashboard credentials to log in successfully.