### PR TITLE
Adding terraform output trimming changes to HEAD

### DIFF
--- a/scenarios/prod/elf_infection/network/network_template.json
+++ b/scenarios/prod/elf_infection/network/network_template.json
@@ -1,11 +1,4 @@
 {
-	"terraform": {
-		"required_providers": {
-			"docker": {
-				"source": "kreuzwerker/docker"
-			}
-		}
-	},
 	"resource": [
 		{
 			"docker_network": [


### PR DESCRIPTION
This pull request integrates the terraform Logging changes during the Start Scenario action when triggered by the onclick from the React dashboard. 

1. Why is this change being made?

     - Problems were reported from a classroom test where scenarios took an unacceptable time to start. Reports of 7+ minutes to start were observed.

2. What has changed?

    - Modified the start scenario function in tasks.py in /py_flask/utils/

3. What concerns do you have?
    - Without a classroom test, real world results on this change cannot be realized effectively

4. How was this tested?
    - Tested starting each scenario in a test env.

5. Any related PRs or CRs?

- https://github.com/edurange/edurange3/pull/73
- https://github.com/edurange/edurange3/pull/76
- Added ELF inflection change to eliminate dual provider error

--------------
- Here is what the new output looks like:

![image](https://github.com/user-attachments/assets/9c404c8b-13f6-45da-9add-bbaf045671f7)

- To bypass the change and see the old output, see the comment on the last line:

![image](https://github.com/user-attachments/assets/43db207e-8b11-40ed-aaf3-0a2e6c1e521f)

- Example of the error capture:

![image](https://github.com/user-attachments/assets/dbb06259-7aab-4eef-90c6-396d5b1a2265)

- If you want to add more phrases to the output, add your text string to the list named "important_phrases" here:

![image](https://github.com/user-attachments/assets/83bc93d5-8bd0-4739-a2d2-7539c0b0c078)
