### PR TITLE
Final version of terraform output update

### DIFF
--- a/scenarios/prod/elf_infection/network/network_template.json
+++ b/scenarios/prod/elf_infection/network/network_template.json
@@ -1,11 +1,4 @@
 {
-	"terraform": {
-		"required_providers": {
-			"docker": {
-				"source": "kreuzwerker/docker"
-			}
-		}
-	},
 	"resource": [
 		{
 			"docker_network": [


### PR DESCRIPTION
### Why was this change needed?
- This change was made to work with the main branch and the destroy scenario which previously was exclude from development.

### What has changed?
- /py_flask/utils/tasks.py start scenario function, added a run command and an apply_terraform function. Added some more functionality and a retry plus good error reporting to the dashboard and console.

### How was this tested?
- Completed the test with only a refresh during ransomware and no server resets.

### Concerns?
- Ransomware failed to start the container terraform, ssh daemon related?

### Handoff:
Nothing is currently in the works to be passed along. Progress bar during long terraform creation testing was inconclusive. Real life testing to see if the bottleneck was resolved by this change has not been proven. Ransomware needs to be tested to see if the scenario_movekeys is functional or causing the error.

### Related:
#78 , #76 


![image](https://github.com/user-attachments/assets/03b04ecb-a65c-4853-942b-62ac10ce4a76)

